### PR TITLE
Remove use of deprecated `std::num::{Zero, One}`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(zero_one, inclusive_range_syntax)]
+#![feature(inclusive_range_syntax)]
 
 #![cfg_attr(test, feature(test))]
 #[cfg(test)]

--- a/src/math/gcd.rs
+++ b/src/math/gcd.rs
@@ -1,14 +1,9 @@
-use std::num::{Zero, One};
-use std::ops::{Shl, Shr, BitAnd, BitOr, Add, Sub, Neg, Rem};
 use std::mem;
 
+use super::{Numeric, Primitive};
+
 pub fn euclid_gcd<T>(mut u: T, mut v: T) -> T
-where T: Copy,
-      T: Zero,
-      T: PartialEq,
-      T: PartialOrd,
-      T: Rem<Output = T>,
-      T: Neg<Output = T>
+where T: Copy + Numeric
 {
     let mut t;
     let zero = T::zero();
@@ -18,25 +13,11 @@ where T: Copy,
         v = t % v;
     }
 
-    if u < zero {
-        -u
-    } else {
-        u
-    }
+    u.abs()
 }
 
 pub fn binary_gcd<T>(mut u: T, mut v: T) -> T
-where T: Copy,
-      T: Zero,
-      T: One,
-      T: PartialEq,
-      T: PartialOrd,
-      T: Shl<T, Output = T>,
-      T: Shr<T, Output = T>,
-      T: BitAnd<Output = T>,
-      T: BitOr<Output = T>,
-      T: Add<Output = T>,
-      T: Sub<Output = T>
+where T: Copy + Primitive
 {
     if u == v {
         return u;

--- a/src/math/lcm.rs
+++ b/src/math/lcm.rs
@@ -1,26 +1,12 @@
-use std::num::Zero;
-use std::ops::{Mul, Div, Neg, Rem};
+use super::Numeric;
 
 pub fn lcm<T>(u: T, v: T) -> T
-    where T: Copy,
-          T: Zero,
-          T: PartialEq,
-          T: PartialOrd,
-          T: Mul<Output = T>,
-          T: Div<Output = T>,
-          T: Rem<Output = T>,
-          T: Neg<Output = T>
+    where T: Copy + Numeric
 {
-
     let gcd = super::gcd(u, v);
     let product = u * v;
-    let zero = T::zero();
 
-    if product < zero {
-        -product / gcd
-    } else {
-        product / gcd
-    }
+    product.abs() / gcd
 }
 
 #[test]

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1,3 +1,5 @@
+use std::ops::{Shl, Shr, BitAnd, BitOr, Add, Sub, Mul, Div, Rem};
+
 pub use self::gcd::euclid_gcd as gcd;
 pub use self::gcd::{euclid_gcd, binary_gcd};
 
@@ -5,3 +7,71 @@ pub use self::lcm::lcm;
 
 mod gcd;
 mod lcm;
+
+/// Trait encompassing all numeric types usable by this module.
+pub trait Numeric: PartialEq + PartialOrd +
+    Add<Output = Self> + Sub<Output = Self> + Mul<Output = Self> + Div<Output = Self> +
+    Rem<Output = Self> + Sized
+{
+    /// Return the absolute value of `self`. No-op for unsigned types.
+    fn abs(self) -> Self;
+
+    /// Return the equivalent of `0` for this type.
+    fn zero() -> Self;
+
+    /// Return the equivalent of `1` for this type.
+    fn one() -> Self;
+}
+
+/// Trait encompassing all numeric types supporting bitwise operations.
+pub trait Primitive: Numeric + Shl<Self, Output = Self> + Shr<Self, Output = Self> +
+BitAnd<Output = Self> + BitOr<Output = Self> {}
+
+macro_rules! impl_numeric_signed {
+    ($($ty:ty),*) => (
+        $(impl Numeric for $ty {
+            fn abs(self) -> Self {
+                // Every signed primitive has an `.abs()` method with guaranteed lowering
+                // to one instruction.
+                self.abs()
+            }
+
+            fn zero() -> Self {
+                0 as $ty
+            }
+
+            fn one() -> Self {
+                1 as $ty
+            }
+        })*
+    )
+}
+
+macro_rules! impl_numeric_unsigned {
+    ($($ty:ty),*) => (
+        $(impl Numeric for $ty {
+            /// No-op
+            fn abs(self) -> Self {
+                self
+            }
+
+            fn zero() -> Self {
+                0 as $ty
+            }
+
+            fn one() -> Self {
+                1 as $ty
+            }
+        })*
+    )
+}
+
+macro_rules! impl_primitive {
+    ($($ty:ty),*) => (
+        $(impl Primitive for $ty {})*
+    )
+}
+
+impl_numeric_signed! { f32, f64, i8, i16, i32, i64 }
+impl_numeric_unsigned! { u8, u16, u32, u64 }
+impl_primitive! { i8, i16, i32, i64, u8, u16, u32, u64 }


### PR DESCRIPTION
Replaces these traits with custom traits, also making it possible to use unsigned types with the functions in `math`.

Alternately, we can use traits from the [`num`](https://crates.io/crates/num) crate, but that comes with its own pros and cons. 

Closes #5 
